### PR TITLE
CDSE OData migration

### DIFF
--- a/noa-harvester/README.md
+++ b/noa-harvester/README.md
@@ -156,7 +156,7 @@ Take a look at the sample config.json.
         "collection": "Sentinel1",
         "search_terms":        
         {
-            "maxRecords": "100",
+            "top": "100",
             "startDate": "2024-01-06",
             .....
         }
@@ -166,7 +166,7 @@ Take a look at the sample config.json.
         "collection": "MODIS",
         "search_terms":
         {
-            "maxRecords": "100",
+            "top": "100",
             "startDate": "2019-01-01",
             .....
         }
@@ -178,7 +178,7 @@ Take a look at the sample config.json.
         "assets": ["visual"],
         "search_terms":
         {
-            "maxRecords": "100",
+            "top": "100",
             "startDate": "2023-05-01",
             "cloud_cover_lt": 90,
             .....

--- a/noa-harvester/config/config_sentinel_1_2.json
+++ b/noa-harvester/config/config_sentinel_1_2.json
@@ -1,25 +1,25 @@
 [
     {   
         "provider": "copernicus",
-        "collection": "Sentinel1",
+        "collection": "SENTINEL-1",
         "search_terms":
         {
-            "maxRecords": "100",
-            "startDate": "2024-01-08",
-            "completionDate": "2024-01-12",
-            "box": "24.15943,38.50005,24.19733,38.51608",
+            "top": "100",
+            "contentDateStartGe": "2024-01-08",
+            "contentDateStartLe": "2024-01-12",
+            "geometry": "POLYGON((24.15943 38.50005, 24.19733 38.50005, 24.19733 38.51608, 24.15943 38.51608, 24.15943 38.50005))",
             "productType": "IW_GRDH_1S-COG"
         }
     },
     {   
         "provider": "copernicus",
-        "collection": "Sentinel2",
+        "collection": "SENTINEL-2",
         "search_terms":
         {
-            "maxRecords": "100",
-            "startDate": "2024-01-05",
-            "completionDate": "2024-01-10",
-            "box": "24.15943,38.50005,24.24733,38.55608",
+            "top": "100",
+            "contentDateStartGe": "2024-01-05",
+            "contentDateStartLe": "2024-01-10",
+            "geometry": "POLYGON((24.15943 38.50005, 24.19733 38.50005, 24.19733 38.51608, 24.15943 38.51608, 24.15943 38.50005))",
             "productType": "S2MSI2A"
         }
     }

--- a/noa-harvester/config/config_sentinel_1_2_modis.json
+++ b/noa-harvester/config/config_sentinel_1_2_modis.json
@@ -1,7 +1,7 @@
 [
     {   
         "provider": "copernicus",
-        "collection": "Sentinel1",
+        "collection": "SENTINEL-1",
         "search_terms":
         {
             "top": "100",

--- a/noa-harvester/config/config_sentinel_1_2_modis.json
+++ b/noa-harvester/config/config_sentinel_1_2_modis.json
@@ -4,22 +4,22 @@
         "collection": "Sentinel1",
         "search_terms":
         {
-            "maxRecords": "100",
-            "startDate": "2024-01-06",
-            "completionDate": "2024-01-10",
-            "box": "24.15943,38.50005,24.24733,38.55608",
+            "top": "100",
+            "contentDateStartGe": "2024-01-06",
+            "contentDateStartLe": "2024-01-10",
+            "geometry": "POLYGON((24.15943 38.50005, 24.19733 38.50005, 24.19733 38.51608, 24.15943 38.51608, 24.15943 38.50005))",
             "productType": "IW_GRDH_1S-COG"
         }
     },
     {   
         "provider": "copernicus",
-        "collection": "Sentinel2",
+        "collection": "SENTINEL-2",
         "search_terms":
         {
-            "maxRecords": "100",
-            "startDate": "2024-01-01",
-            "completionDate": "2024-01-10",
-            "box": "24.15943,38.50005,24.24733,38.55608",
+            "top": "100",
+            "contentDateStartGe": "2024-01-01",
+            "contentDateStartLe": "2024-01-10",
+            "geometry": "POLYGON((24.15943 38.50005, 24.19733 38.50005, 24.19733 38.51608, 24.15943 38.51608, 24.15943 38.50005))",
             "productType": "S2MSI2A"
         }
     },

--- a/noa-harvester/config/config_sentinel_2.json
+++ b/noa-harvester/config/config_sentinel_2.json
@@ -1,17 +1,16 @@
 [
     {   
         "provider": "copernicus",
-        "collection": "Sentinel2",
+        "collection": "SENTINEL-2",
         "search_terms":
         {
-            "maxRecords": "100",
-            "startDate": "2019-12-15",
-            "completionDate": "2021-01-15",
-            "box": "24.15943,38.50005,24.24733,38.55608",
+            "top": "100",
+            "contentDateStartGt": "2020-12-15",
+            "contentDateStartLe": "2021-01-15",
+            "geometry": "POLYGON((21.90 38.95, 23.30 38.95, 23.30 40.10, 21.90 40.10, 21.90 38.95))",           
             "productType": "S2MSI2A",
-            "tileId": "34SEJ",
-            "cloudCover": "[0,20]",
-            "publishedAfter": "2022-01-23"
+            "cloudCover": "[0,50]",
+            "publicationDateGt": "2022-01-23"
         }
     }
 ]

--- a/noa-harvester/config/config_sentinel_3.json
+++ b/noa-harvester/config/config_sentinel_3.json
@@ -1,13 +1,13 @@
 [
     {   
         "provider": "copernicus",
-        "collection": "Sentinel3",
+        "collection": "SENTINEL-3",
         "search_terms":
         {
-            "maxRecords": "1000",
-            "startDate": "2024-01-01",
-            "completionDate": "2024-09-10",
-            "box": "24.15943,38.50005,24.24733,38.55608",
+            "top": "1000",
+            "contentDateStartGe": "2024-01-01",
+            "contentDateStartLe": "2024-09-10",
+            "geometry": "POLYGON((24.15943 38.50005, 24.19733 38.50005, 24.19733 38.51608, 24.15943 38.51608, 24.15943 38.50005))",
             "productType": "SL_2_LST___"
         }
     }

--- a/noa-harvester/config/config_ssm.json
+++ b/noa-harvester/config/config_ssm.json
@@ -4,8 +4,8 @@
         "collection": "CLMS",
         "search_terms":
         {
-            "maxRecords": "2000",
-            "startDate": "2020-10-01",
+            "top": "2000",
+            "contentDateStartGe": "2020-10-01",
             "completionDate": "2025-10-15",
             "box": "19.841309,38.831150,22.873535,40.946714",
             "productIdentifier": "ssm_europe_1km_daily_v1"

--- a/noa-harvester/noaharvester/providers/copernicus.py
+++ b/noa-harvester/noaharvester/providers/copernicus.py
@@ -141,9 +141,9 @@ class Copernicus(DataProvider):
         initial_query_return = len(features)
 
         for feature in features:
-            if feature["properties"]["status"] == "ONLINE":
-                if feature["id"] not in self._downloaded_feature_ids:
-                    self._downloaded_feature_ids.append(feature["id"])
+            if feature['Online']:
+                if feature["Id"] not in self._downloaded_feature_ids:
+                    self._downloaded_feature_ids.append(feature["Id"])
                 else:
                     features.remove(feature)
         click.echo(

--- a/noa-harvester/requirements.txt
+++ b/noa-harvester/requirements.txt
@@ -1,10 +1,12 @@
-cdsetool==0.2.13
+cdsetool==0.3.1
 click==8.1.7
 earthaccess==0.9.0
 kafka-python-ng==2.2.3
-psycopg==3.2.3
+psycopg[binary]==3.2.3
+PyJWT<2.6
 pyproj==3.6.1
 pyshp==2.3.1
 pystac-client==0.8.2
 pytest==8.1.1
 pytest-cov==4.1.0
+setuptools==80.0.0

--- a/noa-harvester/tests/conftest.py
+++ b/noa-harvester/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 
 CONTENT = (
-    '[{"provider":"copernicus","collection":"Sentinel1","search_terms":{}},'
+    '[{"provider":"copernicus","collection":"SENTINEL-1","search_terms":{}},'
     '{"provider":"earthdata","collection":"MODIS","search_terms":{}}]'
 )
 

--- a/noa-preprocess/noapreprocess/preprocess.py
+++ b/noa-preprocess/noapreprocess/preprocess.py
@@ -171,16 +171,18 @@ class Preprocess:
             if file.endswith(default_s1_raster_suffix):
                 # absoluteOrbitNumber
                 filename_parts = Path(file).name.split("-")
-                orbit_number = filename_parts[-3]
-                year = filename_parts[-5].split("T")[0][:4]
-                month = filename_parts[-5].split("T")[0][4:6]
-                day = filename_parts[-5].split("T")[0][6:8]
+                # orbit_number = filename_parts[-3]
+                year = filename_parts[-5].lower().split("t")[0][:4]
+                month = filename_parts[-5].lower().split("t")[0][4:6]
+                day = filename_parts[-5].lower().split("t")[0][6:8]
                 data = archive.read(file, self._input_path)
                 output_file_path = Path(
-                    self._output_path, orbit_number, year, month, day, Path(file).name
+                    # self._output_path, orbit_number, year, month, day, Path(file).name
+                    self._output_path, year, month, day, Path(file).name
                 )
                 os.makedirs(
-                    Path(self._output_path, orbit_number, year, month, day),
+                    # Path(self._output_path, orbit_number, year, month, day),
+                    Path(self._output_path, year, month, day),
                     exist_ok=True,
                 )
                 output_file_path.write_bytes(data)


### PR DESCRIPTION
This PR updates noa-harvester to support the latest CDSETool changes following the deprecation of the previous OpenSearch-based query flow.

The main change is the migration to **cdsetool==0.3.1** and the adaptation of Copernicus query configuration along with download handling to the new CDSE OData-style product response format.

Changes

- Upgraded cdsetool to version 0.3.1.
- Updated Copernicus query parameters:
    - Replaced `maxRecords` with `top`.
    - Replaced `startDate` with `contentDateStartGe`.
    - Replaced `completionDate` with `contentDateStartLe`.
- Updated Sentinel collection names to the current CDSE format:
   - Sentinel1 → SENTINEL-1
   - Sentinel2 → SENTINEL-2
- Updated spatial query examples to use CDSE-compatible geometry
- Adapted the Copernicus download logic to support the new CDSETool product response structure using update fields such as `Id`, `Name`, `Online`
- Updated local dependency compatibility for Windows/conda development:
   - psycopg[binary]
   - setuptools<81
   - PyJWT<2.6